### PR TITLE
remove duplicated outputs

### DIFF
--- a/part_3_convert_json.py
+++ b/part_3_convert_json.py
@@ -14,14 +14,14 @@ import json
 
 
 def make_CClvPack_from_json( json_data ):
-    new_level = CCLevel()
     new_level_pack = CCLevelPack()
-    new_field3 = CCMapTitleField(" ")
-    new_field6 = CCEncodedPasswordField("0000")
-    new_field7 = CCMapHintField(" ")
-    new_field8 = CCMonsterMovementField(" ")
     
     for lv in cclv_json_data:
+        new_level = CCLevel()
+        new_field3 = CCMapTitleField(" ")
+        new_field6 = CCEncodedPasswordField("0000")
+        new_field7 = CCMapHintField(" ")
+        new_field8 = CCMonsterMovementField(" ")
         
         new_level.level_number = json_data[lv]["Level"]
         new_level.time = json_data[lv]["Time limit"]


### PR DESCRIPTION
Remove the duplicate printing of level 2, as well as duplicated optional fields.

    Problem:
      1. When running part_3_convert_json.py, we saw that the contents of level 2 are printed out twice, instead of seeing level 1 and level 2 in order.
      2. Also, optional fields are printed twice in the second repetition of the field

    Solution:
      In each iteration of the loop, create new objects for the level and fields read in. The
      duplication was caused by adding the exact same object to the level pack twice.